### PR TITLE
Match Plausible Overview

### DIFF
--- a/src/assetbundles/plausible/dist/css/Plausible.css
+++ b/src/assetbundles/plausible/dist/css/Plausible.css
@@ -21,12 +21,13 @@
  	margin-right: 48px;
 }
 
-
 .overview-title {
 	padding-top: 6px;
 	font-weight: 400;
 	margin-bottom: 4px;
+	text-transform: uppercase;
 }
+
 .overview-value {
 	margin: 0;
 	font-weight: 600;

--- a/src/assetbundles/plausible/dist/css/Plausible.css
+++ b/src/assetbundles/plausible/dist/css/Plausible.css
@@ -44,6 +44,7 @@
 .overview-value .percentage {
 	font-size: 12px;
 	font-weight: 500;
+	vertical-align: middle;
 }
 
 .overview-value .up {

--- a/src/templates/_components/widgets/Overview/body.twig
+++ b/src/templates/_components/widgets/Overview/body.twig
@@ -24,6 +24,15 @@
 			</p>
 		</div>
 		<div>
+			<p class="overview-title">Bounce rate</p>
+			<p class="overview-value">
+				{{ results.bounce_rate.value }}%
+				{% set changeValue = results.bounce_rate.change ?? 0 %}
+				{% set change = changeValue > 0 ? 'down' : changeValue < 0 ? 'up' : 'same' %}
+				{% set icon = changeValue > 0 ? '↑' : changeValue < 0 ? '↓' : '--' %}
+				<span class="percentage"><span class="{{ change }}">{{ icon }}</span>{{ results.bounce_rate.change|replace('-', '') }}%</span></p>
+		</div>
+		<div>
 			<p class="overview-title">Visit duration</p>
 			<p class="overview-value">
 				{{ results.visit_duration.value|prettyTime }}
@@ -32,15 +41,6 @@
 				{% set icon = changeValue > 0 ? '↑' : changeValue < 0 ? '↓' : '--' %}
 				<span class="percentage"><span class="{{ change }}">{{ icon }}</span>{{ results.visit_duration.change|replace('-', '') }}%</span>
 			</p>
-		</div>
-		<div>
-			<p class="overview-title">Bounce rate</p>
-			<p class="overview-value">
-				{{ results.bounce_rate.value }}%
-				{% set changeValue = results.bounce_rate.change ?? 0 %}
-				{% set change = changeValue > 0 ? 'down' : changeValue < 0 ? 'up' : 'same' %}
-				{% set icon = changeValue > 0 ? '↑' : changeValue < 0 ? '↓' : '--' %}
-				<span class="percentage"><span class="{{ change }}">{{ icon }}</span>{{ results.bounce_rate.change|replace('-', '') }}%</span></p>
 		</div>
 	{% endif %}
 </div>


### PR DESCRIPTION
This PR swaps the position of the “Bounce rate” and “Visit duration” stats and makes some styling tweaks, to more closely match the Plausible overview.

![Screenshot 2023-06-15 at 20 45 37](https://github.com/shornuk/craft-plausible/assets/57572400/15fef671-7421-49e3-af65-d62b80a81990)

![Screenshot 2023-06-15 at 20 44 09](https://github.com/shornuk/craft-plausible/assets/57572400/a0b3f1e9-6713-4e77-9ab9-9d8a8db3ec32)
